### PR TITLE
Add relative template resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,5 @@ Option | Type | Default | Details
 ------ | ---- | ------- | -------
 basepath | string | `""` | Base path to look up referenced templates from
 pattern | RegExp | `/'@@import ([a-zA-Z0-9\-_.\\/]+)'/g` | Pattern to match template references. Should have one capture group that will match template path
+relative | boolean | `false` | Resolve templates relative to the file being processed
 debug | boolean | `false` | Displays some information while working - processed files, found references, injection result

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var xtend = require('xtend');
 module.exports = function(options) {
     var opts = xtend({
         basepath: '',
+        relative: false,
         pattern: /'@@import ([a-zA-Z0-9\-_.\\/]+)'/g,
         debug: false
     }, options);
@@ -18,7 +19,11 @@ module.exports = function(options) {
 
             var process = function(contents) {
                 return contents.replace(opts.pattern, function(match, filepath) {
-                    var fp = path.join(opts.basepath, filepath);
+                    var fp = '';
+                    if(opts.relative)
+                        fp = path.join(path.dirname(file.path), opts.basepath, filepath);
+                    else
+                        fp = path.join(opts.basepath, filepath);
 
                     try {
                         var filecontents = fs.readFileSync(fp, { encoding: 'utf8' });
@@ -42,7 +47,7 @@ module.exports = function(options) {
                     file.contents = new Buffer(process(data));
                     callback(null, file);
                 });
-            } else { 
+            } else {
                 callback(null, file);
             }
         }


### PR DESCRIPTION
This is so that we can resolve files relatively, like how angular 2 does it.

I.E. if I have these files:

```
src/components/my-component.js
src/components/my-component.html
```

And within `my-component.js` I have:

```
export default {
  template: '@@import my-component.html';
  // ...
}
```

It could resolve with this PR's code and this task config:

```javascript
gulp.task('inject:stage', () => {
  return gulp.src('src/**/*.js')
    .pipe(inject({
      relative: true
    }))
    .pipe(gulp.dest('dist'));
});
```
